### PR TITLE
Document NEARFS environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Means that you can have GitHub-specific account which cannot do anything else be
 - `IPFS_GATEWAY_LIST` – comma-separated list of IPFS gateways to hydrate
 - `NEAR_SIGNER_ACCOUNT` - NEAR account to use for signing IPFS URL update transaction. Defaults to `<destination-account.near>`.
 - `NEAR_SIGNER_KEY` - NEAR account private key to use for signing. Should have base58-encoded key starting with `ed25519:`. Defaults to using key from `~/.near-credentials/`.
+- `NEARFS_GATEWAY_URL` - URL of the NEARFS gateway.
+- `NEARFS_GATEWAY_TIMEOUT` - time until requests to the NEARFS gateway time out, in milliseconds.
+- `NEARFS_GATEWAY_RETRY_COUNT` - the maximum number of attempts to check if a block exists on NEARFS.
 
 ## How it works
 


### PR DESCRIPTION
This PR adds NEARFS-related environment variables in README.md.

Also, I noticed that `WEB3_STORAGE_TOKEN` variable is referred to as `WEB3_TOKEN` in https://github.com/vgrichina/web4-deploy/blob/4c68f4ced486845c32b611a25225c54e7ef979e0/bin/deploy#L78, but `WEB3_STORAGE_TOKEN` is probably a more correct name for this variable, and I don't have a web3storage account, so this PR doesn't include this change.